### PR TITLE
Major overhaul of jamfpro.css for dark mode

### DIFF
--- a/jamfpro.css
+++ b/jamfpro.css
@@ -1,25 +1,104 @@
 * {
-    font-family: BlinkMacSystemFont,-apple-system,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue","Helvetica","Arial",sans-serif !important;
+    font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
 }
-
+#notification-modal .modal-body .notification-alert{
+    border:1px solid #3b3b3b;
+}
 a {
     color: #265fdf;
+    font-weight: 700;
+}
+h1, h2, h3, h4, h5, h6 {
+    font-family: BlinkMacSystemFont, -apple-system, ProximaNova,"Helvetica Neue",Verdana,sans-serif;
+    font-weight: normal;
+    font-style: normal;
+    color: #dddddd;
+    text-rendering: optimizeLegibility;
+    margin-top: .2rem;
+    margin-bottom: .5rem;
+    line-height: 1.4;
+}
+.login-page .login-form input {
+    display: block;
+    height: 30px;
+    margin: 6px 10px 11px;
+    border: 0;
+    width: 75%;
+    padding: 8px 16px;
+    color: #dddddd;
+    font-size: 14px;
+}
+
+input {
+    background-color: #4e5a6f;
+    color: #ffffff;
+    cursor: text;
+    border-width: 2px;
+    border-style: inset;
+    border-color: initial;
+    border-image: initial;
+}
+input:focus {
+    background-color: #363e4c;
+    color: #ffffff;
+    cursor: text;
+    border-width: 2px;
+    border-style: inset;
+    border-color: initial;
+    border-image: initial;
+}
+
+
+input[type="text"],input[type="password"],input[type="date"],input[type="datetime"],input[type="datetime-local"],input[type="month"],input[type="week"],input[type="email"],input[type="number"],input[type="search"],input[type="tel"],input[type="time"],input[type="url"],input[type="color"],textarea
+{
+	display: block;
+	width: 100%;
+	height: 2.4rem;
+	padding: .5rem;
+	margin: 0 0 1rem 0;
+	border: 1px solid #cbd0d8;
+	border-radius: 0;
+	background: #4e5a6f;
+	color: #dddddd;
+	font-size: 1rem;
+	-webkit-font-smoothing: antialiased;
+	vertical-align: middle;
+}
+
+input[type="text"]:hover,input[type="password"]:hover,input[type="date"]:hover,input[type="datetime"]:hover,input[type="datetime-local"]:hover,input[type="month"]:hover,input[type="week"]:hover,input[type="email"]:hover,input[type="number"]:hover,input[type="search"]:hover,input[type="tel"]:hover,input[type="time"]:hover,input[type="url"]:hover,input[type="color"]:hover,textarea:hover
+{
+	border: solid 1px #268aff;
+	background: #4e5a6f;
+	color: #dddddd;
+}
+
+input[type="text"]:focus,input[type="password"]:focus,input[type="date"]:focus,input[type="datetime"]:focus,input[type="datetime-local"]:focus,input[type="month"]:focus,input[type="week"]:focus,input[type="email"]:focus,input[type="number"]:focus,input[type="search"]:focus,input[type="tel"]:focus,input[type="time"]:focus,input[type="url"]:focus,input[type="color"]:focus,textarea:focus
+{
+	outline: 0;
+	border: solid 1px #268aff;
+	background: #363e4c;
+	color: #ffffff;
+}
+
+input.disabled.jamf-input-text, .jamf-table-theme input.disabled.ag-filter-filter, input.jamf-input-text[disabled], .jamf-table-theme input.ag-filter-filter[disabled], input.jamf-input-text[disabled]:hover, .jamf-table-theme input.ag-filter-filter[disabled]:hover {
+    cursor: not-allowed;
+    border-color: #cbd0d8;
+    background-color: #414753;
 }
 
 html, body, .jamf-list tbody td, .jamf-inner-list tbody td, .jamf-label {
-    color: #212121;
+    color: #DDDDDD;
+    background: inherit;
 }
 
 .jamf-list tbody td a, .jamf-inner-list tbody td a {
-    color: #156ed6;
+    color: #307fff;
 }
-
 .list-header, .jamf-tabs {
-    background: #F3F3F3;
+    background: #333333;
 }
-
 .jamf-tabs li:hover a, .jamf-tabs li.active a, jamf-scrollbox-sidenav .side-navigation>li a .heading {
     color: #1247c1;
 }
@@ -27,22 +106,1089 @@ html, body, .jamf-list tbody td, .jamf-inner-list tbody td, .jamf-label {
 .jamf-list thead th, .jamf-inner-list thead th {
     color: #4580c5;
 }
-
 .even, .label-value-wrapper:nth-child(even) {
-    background: #FBFBFB;
+    background: #303030;
+}
+.reverse>.label-value-wrapper:nth-child(odd){
+    background-color:#555A5F
+}
+.reverse>.label-value-wrapper:nth-child(even){
+    background-color:#6f6f6f
+}
+.nav-group-header {
+    font-weight: 700;
+    color: #dddddd;
+    text-transform: uppercase;
+    font-size: 11px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    letter-spacing: 1px;
+}
+
+.login-page .login-form input {
+    display: block;
+    height: 30px;
+    margin: 6px 10px 11px;
+    border: 0;
+    width: 75%;
+    padding: 8px 16px;
+    color: #dddddd;
+    font-size: 14px;
+}
+
+.login-page .login-form input:focus
+{
+	outline: 0;
+	color: #dddddd;
+}
+
+
+.jamf-pro-dashboard #dashboard-container .dashboard-content #dashboard-sample, .configurationprofilesdashboard #dashboard-container .dashboard-content #dashboard-sample, .distributionserverdashboard #dashboard-container .dashboard-content #dashboard-sample, .policiesdashboard #dashboard-container .dashboard-content #dashboard-sample {
+    background: #555a5f;
+    background-size: 10px 10px;
+}
+
+.jamf-pro-dashboard #dashboard-container .dashboard-content #dashboard-sample .dashboard-sample-text .dashboard-sample-header h3, .configurationprofilesdashboard #dashboard-container .dashboard-content #dashboard-sample .dashboard-sample-text .dashboard-sample-header h3, .distributionserverdashboard #dashboard-container .dashboard-content #dashboard-sample .dashboard-sample-text .dashboard-sample-header h3, .policiesdashboard #dashboard-container .dashboard-content #dashboard-sample .dashboard-sample-text .dashboard-sample-header h3 {
+    font-size: 36px;
+    font-weight: 200;
+    font-style: normal;
+    font-stretch: normal;
+    line-height: 1;
+    color: #dddddd;
+    padding: 0;
+}
+.jamf-pro-dashboard #dashboard-container .dashboard-content #dashboard-sample::after, .configurationprofilesdashboard #dashboard-container .dashboard-content #dashboard-sample::after, .distributionserverdashboard #dashboard-container .dashboard-content #dashboard-sample::after, .policiesdashboard #dashboard-container .dashboard-content #dashboard-sample::after {
+    content: "";
+    height: 30px;
+    width: 100%;
+    background: #555a5f;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+}
+.jamf-pro-dashboard #dashboard-container .dashboard-content.dashboard-content-index, .configurationprofilesdashboard #dashboard-container .dashboard-content.dashboard-content-index, .distributionserverdashboard #dashboard-container .dashboard-content.dashboard-content-index, .policiesdashboard #dashboard-container .dashboard-content.dashboard-content-index {
+    background-color: #555a5f;
+}
+.jamf-pro-dashboard #dashboard-container .dashboard-content #dashboard-sample .dashboard-sample-text p, .configurationprofilesdashboard #dashboard-container .dashboard-content #dashboard-sample .dashboard-sample-text p, .distributionserverdashboard #dashboard-container .dashboard-content #dashboard-sample .dashboard-sample-text p, .policiesdashboard #dashboard-container .dashboard-content #dashboard-sample .dashboard-sample-text p {
+    font-size: 14px;
+    font-weight: normal;
+    font-style: normal;
+    font-stretch: normal;
+    color: #dddddd;
+    margin-top: 14px;
+    margin-bottom: 24px;
+}
+
+.jamf-pro-dashboard #dashboard-container .dashboard-content h3 a, .jamf-pro-dashboard #dashboard-container .dashboard-content h3 a.view-all, .jamf-pro-dashboard #dashboard-container .dashboard-content h3.view-all, .configurationprofilesdashboard #dashboard-container .dashboard-content h3 a, .configurationprofilesdashboard #dashboard-container .dashboard-content h3 a.view-all, .configurationprofilesdashboard #dashboard-container .dashboard-content h3.view-all, .distributionserverdashboard #dashboard-container .dashboard-content h3 a, .distributionserverdashboard #dashboard-container .dashboard-content h3 a.view-all, .distributionserverdashboard #dashboard-container .dashboard-content h3.view-all, .policiesdashboard #dashboard-container .dashboard-content h3 a, .policiesdashboard #dashboard-container .dashboard-content h3 a.view-all, .policiesdashboard #dashboard-container .dashboard-content h3.view-all {
+    font-size: 17px;
+    font-weight: 600;
+    color: #dddddd;
+    margin: 0;
+}
+
+.jamf-pro-dashboard #dashboard-container .dashboard-content h3::after, .configurationprofilesdashboard #dashboard-container .dashboard-content h3::after, .distributionserverdashboard #dashboard-container .dashboard-content h3::after, .policiesdashboard #dashboard-container .dashboard-content h3::after {
+    content: "";
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-flex: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+    margin-left: 20px;
+    border-bottom: solid 1px #dddddd;
+    opacity: .2;
+}
+
+.jamf-assistant-sidebar {
+    background: #333333;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    height: auto;
+    position: relative;
+    overflow: hidden;
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    -webkit-box-flex: 0;
+    -ms-flex: 0 0 25%;
+    flex: 0 0 25%;
+    max-width: 25%;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-flow: column nowrap;
+    flex-flow: column nowrap;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    -webkit-box-pack: justify;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
+    -webkit-box-ordinal-group: 1;
+    -ms-flex-order: 0;
+    order: 0;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+}
+
+.radio-button-wrapper .label {
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    font-size: 14px;
+    color: #dddddd;
+    margin-right: auto;
+    margin-bottom: .75rem;
+    margin-left: .2rem;
+    line-height: 1.2;
+    position: relative;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    cursor: pointer;
+}
+
+.jamf-assistant-actions {
+    background: linear-gradient(to bottom,rgba(24,24,24,0) 0,rgba(24,24,24,0.75) 25%,rgba(24,24,24,0.95) 50%);
+    z-index: 21;
+    bottom: 0;
+    right: 0;
+    text-align: right;
+    position: relative;
+    padding: 21px;
+}
+
+.jamf-label.section-label, .jamf-alert .jamf-alert-message .section-label.jamf-alert-title, .patch-remote-source-test-pane #message-wrapper .summary .section-label.summary-title, .jamf-settings-main .settings-section .nav-item-group .nav-group-header {
+    color: #ffffff;
+    background-color: inherit;
+    font-weight: 600;
+    font-size: 17px;
 }
 
 /* Labels */
-.jamf-label.main-label, .jamf-alert .jamf-alert-message .jamf-alert-title, .jamf-form-group .jamf-form-group .section-label, .patch-remote-source-test-pane #message-wrapper .summary .summary-title {
-    color: #404040;
+ .jamf-label.main-label, .jamf-alert .jamf-alert-message .jamf-alert-title, .jamf-form-group .jamf-form-group .section-label, .patch-remote-source-test-pane #message-wrapper .summary .summary-title {
+    color: #555555;
+    background-color: inherit;
 }
+
+.jamf-info .jamf-info-content .main-label, .jamf-info .jamf-info-content .jamf-alert .jamf-alert-message .jamf-alert-title, .jamf-alert .jamf-alert-message .jamf-info .jamf-info-content .jamf-alert-title, .jamf-info .jamf-info-content .patch-remote-source-test-pane #message-wrapper .summary .summary-title, .patch-remote-source-test-pane #message-wrapper .summary .jamf-info .jamf-info-content .summary-title {
+    display: block;
+    margin-bottom: 5px;
+    color: #6f6f6f;
+    background: transparent;
+}
+
+.jamf-standard-buttons
+{
+	background: linear-gradient(to bottom,rgba(24,24,24,0) 0,rgba(24,24,24,0.75) 25%,rgba(24,24,24,0.95) 50%);
+	position: fixed;
+	display: flex;
+	-webkit-box-align: start;
+	-ms-flex-align: start;
+	align-items: flex-start;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
+	bottom: 0;
+	right: 0;
+	left: 0;
+	z-index: 1;
+	padding: 21px;
+}
+
 
 /* Menu and payload item backgrounds */
-jamf-scrollbox-sidenav .side-navigation>li.current a, .jamf-section:nth-of-type(even) {
-    background: #FBFBFB;
+ jamf-scrollbox-sidenav .side-navigation>li.current a, .jamf-section:nth-of-type(even) {
+    background: #303030;
 }
-
 /* Rough tweak to show full opacity when "previewing" a policy before editing */
-.disabled {
+ .disabled 
+{
     opacity: 1 !important;
 }
+
+.flex-container-column 
+{
+    background-color: #303030;
+}
+
+.login-page #jamf-logo-login 
+{
+    background-color: #5b6982;
+}
+
+.login-page .login-form
+{
+    background-color: #778eb1;
+}
+
+breadcrumb .breadcrumb 
+{
+    background-color: #555555;
+    border-bottom: 0px;
+}
+
+breadcrumb 
+{
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    position: relative;
+    display: block;
+    pointer-events: auto;
+    background: #3b3b3b;
+    min-height: 82px;
+}
+
+breadcrumb .breadcrumb-title
+{
+    color: #DDDDDD;
+    line-height: 1.3;
+    font-weight: 600;
+}
+
+breadcrumb .breadcrumb-glow
+{
+    pointer-events:none;
+    position:absolute;
+    left:0;
+    right:0;
+    bottom:0;
+    height:82px;
+    -webkit-box-shadow:0 10px 10px -8px #333333;
+    box-shadow:0 10px 10px -8px #333333;
+}
+
+.form-inside 
+{
+    background-color: #5b6982;
+}
+
+#main-ui-view 
+{
+    background-color: #181818;
+}
+
+#iframe-preloader-cover 
+{
+    background: rgba(64, 64, 64, 0.75);
+}
+
+.payload .payload-heading 
+{
+    color: #DDDDDD;
+}
+
+.jamf-scrollbox
+{
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    -webkit-box-orient:horizontal;
+    -webkit-box-direction:normal;
+    -ms-flex-direction:row;
+    flex-direction:row;
+    -webkit-box-flex:1;
+    -ms-flex-positive:1;
+    flex-grow:1;
+    border-bottom:1px solid #555555;
+    overflow:hidden
+}
+
+.jamf-scrollbox .scrollbox-side
+{
+    -ms-flex-preferred-size:25%;
+    flex-basis:25%;
+    -webkit-box-flex:0;
+    -ms-flex-positive:0;
+    flex-grow:0;
+    -ms-flex-negative:0;
+    flex-shrink:0;
+    border-right:1px solid #555555;
+    min-width:200px;
+    -webkit-overflow-scrolling:auto
+}
+
+jamf-scrollbox-sidenav .side-navigation>li
+{
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    -webkit-box-orient:vertical;
+    -webkit-box-direction:normal;
+    -ms-flex-direction:column;
+    flex-direction:column;
+    padding:0;
+    border-bottom:1px solid #555555;
+    position:relative
+}
+
+jamf-scrollbox-sidenav .side-navigation>li a .heading
+{
+    font-size: 15px;
+    font-weight: 600;
+    color: #8d95a0;
+    text-shadow: 1px 1px 0 #000000;
+    display: block;
+    width: 100%;
+    line-height: 1.2;
+}
+jamf-scrollbox-sidenav .side-navigation>li.current a .heading
+{
+    color: #a9c2ef;
+    font-weight: 900;
+}
+jamf-scrollbox-sidenav .side-navigation>li a .subheading
+{
+    font-size: 12px;
+    color: #888888;
+    font-weight: 400;
+    display: block;
+    width: 100%;
+    line-height: 1.3;
+}
+.jamf-form-group
+{
+    border-left: 1px solid #3f3f3f;
+    padding-left: 28px;
+    margin-left: 1rem;
+    margin-bottom: 1rem;
+}
+
+.unit-of-measurement-wrapper .unit-of-measurement
+{
+    display: inline-block;
+    background-color: inherit;
+}
+
+.jamf-label.main-label,.jamf-alert .jamf-alert-message .jamf-alert-title,.jamf-form-group .jamf-form-group .section-label,.patch-remote-source-test-pane #message-wrapper .summary .summary-title
+{
+	color: #5b6982;
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+}
+
+.jamf-label.main-label.disabled,.jamf-alert .jamf-alert-message .disabled.jamf-alert-title,.jamf-form-group .jamf-form-group .disabled.section-label,.patch-remote-source-test-pane #message-wrapper .summary .disabled.summary-title,.jamf-label.main-label[disabled],.jamf-alert .jamf-alert-message .jamf-alert-title[disabled],.jamf-form-group .jamf-form-group .section-label[disabled],.patch-remote-source-test-pane #message-wrapper .summary .summary-title[disabled],.disabled .jamf-label.main-label,.disabled .jamf-alert .jamf-alert-message .jamf-alert-title,.jamf-alert .jamf-alert-message .disabled .jamf-alert-title,.disabled .jamf-form-group .jamf-form-group .section-label,.jamf-form-group .jamf-form-group .disabled .section-label,.disabled .patch-remote-source-test-pane #message-wrapper .summary .summary-title,.patch-remote-source-test-pane #message-wrapper .summary .disabled .summary-title
+{ 
+    color: #666;
+}
+
+.jamf-label.main-label.normal-case,.jamf-alert .jamf-alert-message .normal-case.jamf-alert-title,.jamf-form-group .jamf-form-group .normal-case.section-label,.patch-remote-source-test-pane #message-wrapper .summary .normal-case.summary-title
+{
+	text-transform: none;
+	letter-spacing: normal;
+	font-weight: normal;
+	font-size: 14px;
+}
+
+.jamf-label.caption-label,.jamf-alert .jamf-alert-message .caption-label.jamf-alert-title,.patch-remote-source-test-pane #message-wrapper .summary .caption-label.summary-title
+{
+    font-weight: 700;
+}
+
+.jamf-label.section-label,.jamf-alert .jamf-alert-message .section-label.jamf-alert-title,.patch-remote-source-test-pane #message-wrapper .summary .section-label.summary-title,.jamf-settings-main .settings-section .nav-item-group .nav-group-header
+{
+	color: #dddddd;
+	font-size: 17px;
+}
+
+.jamf-label.title-label, .jamf-alert .jamf-alert-message .title-label.jamf-alert-title, .patch-remote-source-test-pane #message-wrapper .summary .title-label.summary-title {
+    font-size: 20px;
+    color: #dddddd;
+    font-weight: 400;
+    margin-right: 24px;
+    background: transparent;
+}
+
+.jamf-label.action-label,.jamf-alert .jamf-alert-message .action-label.jamf-alert-title,.patch-remote-source-test-pane #message-wrapper .summary .action-label.summary-title{
+    display:block;
+    color:#FFFFFF;
+    background-color: inherit;
+    line-height:1.3
+}
+
+.jamf-label.main-label.disabled, .jamf-alert .jamf-alert-message .disabled.jamf-alert-title, .jamf-form-group .jamf-form-group .disabled.section-label, .patch-remote-source-test-pane #message-wrapper .summary .disabled.summary-title, .jamf-label.main-label[disabled], .jamf-alert .jamf-alert-message .jamf-alert-title[disabled], .jamf-form-group .jamf-form-group .section-label[disabled], .patch-remote-source-test-pane #message-wrapper .summary .summary-title[disabled], .disabled .jamf-label.main-label, .disabled .jamf-alert .jamf-alert-message .jamf-alert-title, .jamf-alert .jamf-alert-message .disabled .jamf-alert-title, .disabled .jamf-form-group .jamf-form-group .section-label, .jamf-form-group .jamf-form-group .disabled .section-label, .disabled .patch-remote-source-test-pane #message-wrapper .summary .summary-title, .patch-remote-source-test-pane #message-wrapper .summary .disabled .summary-title {
+    color: #7d7d7d;
+    background-color: inherit;
+    
+}
+.sublabel, .description {
+    transition-delay: 0;
+    font-size: 12px;
+    color: #7d7d7d;
+    background-color: inherit;
+    text-transform: none;
+    font-weight: initial;
+    letter-spacing: normal;
+}
+
+jamf-tabs[tab-type="side-tabs"] ul.jamf-tabs li.active a{
+    background-color:#555A5F
+}
+
+jamf-tabs[tab-type="side-tabs"] .jamf-tabs-ul-wrapper{
+    list-style:none;
+    margin-left:0;
+    -ms-flex-preferred-size:25%;
+    flex-basis:25%;
+    -webkit-box-flex:0;
+    -ms-flex-positive:0;
+    flex-grow:0;
+    -ms-flex-negative:0;
+    flex-shrink:0;
+    border-right:1px solid #555555;
+    min-width:200px;
+    -webkit-overflow-scrolling:auto;
+    overflow:auto
+}
+.jamf-tabs{
+    -webkit-box-shadow:0 1px 5px 0 rgba(51,51,51,0.15),0 1px 0 0 #fff,0 -1px 0 0 #e6e6e6,inset 0 -2px 0 0 #FF0000;
+    box-shadow:0 1px 5px 0 rgba(51,51,51,0.15),0 1px 0 0 #fff,0 -1px 0 0 #e6e6e6,inset 0 -2px 0 0 #303030;
+    list-style:none;
+    height:64px;
+    margin:0;
+    padding:0 40px;
+    border-bottom:1px solid #303030;
+    overflow:auto;
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    -ms-flex-wrap:nowrap;
+    flex-wrap:nowrap;
+    white-space:nowrap;
+    -ms-flex-negative:0;
+    flex-shrink:0;
+    -webkit-user-select:none;
+    -moz-user-select:none;
+    -ms-user-select:none;
+    user-select:none;
+    z-index:1
+}
+jamf-tabs[tab-type="side-tabs"] ul.jamf-tabs li.display-errors:hover,jamf-tabs[tab-type="side-tabs"] ul.jamf-tabs li.display-errors.active,jamf-tabs[tab-type="side-tabs"] ul.jamf-tabs li.display-errors:hover.active{
+    border-bottom:1px solid #555555;
+}
+.jamf-tabs li:hover a, .jamf-tabs li.active a, jamf-scrollbox-sidenav .side-navigation>li a .heading {
+    color: #DDDDDD;
+}
+.payload .table-wrapper .reorder-buttons,.content .table-wrapper .reorder-buttons{
+    border-left:solid 1px #555555;
+    text-align:left;
+    padding-left:5px;
+    min-width:65px;
+    overflow:auto
+}
+
+.jamf-list thead th,.jamf-inner-list thead th{
+    border-bottom:1px solid #555555;
+    -webkit-transition:padding .3s;
+    transition:padding .3s;
+    color:#5b6982;
+    font-size:11px;
+    text-transform:uppercase;
+    font-weight:700;
+    letter-spacing:1px;
+    text-align:left;
+    position:relative;
+    white-space:nowrap;
+    overflow:hidden;
+    text-overflow:ellipsis
+}
+.jamf-list thead th.bordered,.jamf-inner-list thead th.bordered{
+    border-left-color:#555555;
+    border-right-color:#555555;
+}
+
+.jamf-list thead th .table-divider::after,.jamf-inner-list thead th .table-divider::after{
+    background:#555555;
+    height:60%;
+    top:40%
+}
+.jamf-list tbody td.bordered,.jamf-inner-list tbody td.bordered{
+    border-right-color:#555555;
+    border-left-color:#555555;
+}
+.jamf-list.bordered-left,.jamf-inner-list.bordered-left{
+    border-left:1px solid #555555;
+}
+
+
+.jamf-list:not(.jamf-list-expandable) tbody tr:nth-child(odd),.jamf-list:not(.jamf-inner-list-expandable) tbody tr:nth-child(odd),.jamf-inner-list:not(.jamf-list-expandable) tbody tr:nth-child(odd),.jamf-inner-list:not(.jamf-inner-list-expandable) tbody tr:nth-child(odd){
+    background-color:#2F2F2F
+}
+.jamf-list:not(.jamf-list-expandable) tbody tr:nth-child(even),.jamf-list:not(.jamf-inner-list-expandable) tbody tr:nth-child(even),.jamf-inner-list:not(.jamf-list-expandable) tbody tr:nth-child(even),.jamf-inner-list:not(.jamf-inner-list-expandable) tbody tr:nth-child(even){
+    background-color:#3f3f3f
+}
+.jamf-list:not(.jamf-list-expandable) tbody tr td,.jamf-list:not(.jamf-inner-list-expandable) tbody tr td,.jamf-inner-list:not(.jamf-list-expandable) tbody tr td,.jamf-inner-list:not(.jamf-inner-list-expandable) tbody tr td{
+    border-bottom:1px solid #555555
+}
+.jamf-list.jamf-list-expandable tbody tr.odd,.jamf-list.jamf-inner-list-expandable tbody tr.odd,.jamf-inner-list.jamf-list-expandable tbody tr.odd,.jamf-inner-list.jamf-inner-list-expandable tbody tr.odd{
+    background-color:#2F2F2F
+}
+/*
+.jamf-list.jamf-list-expandable tbody tr.even,.jamf-list.jamf-inner-list-expandable tbody tr.even,.jamf-inner-list.jamf-list-expandable tbody tr.even,.jamf-inner-list.jamf-inner-list-expandable tbody tr.even{
+    background-color:#666666
+}
+*/
+
+.jamf-list.jamf-list-expandable tbody tr td,.jamf-list.jamf-inner-list-expandable tbody tr td,.jamf-inner-list.jamf-list-expandable tbody tr td,.jamf-inner-list.jamf-inner-list-expandable tbody tr td{
+    border-bottom:1px solid #555555
+}
+.jamf-list:not(.jamf-list-expandable) thead tr:nth-child(odd),.jamf-list:not(.jamf-inner-list-expandable) thead tr:nth-child(odd),.jamf-inner-list:not(.jamf-list-expandable) thead tr:nth-child(odd),.jamf-inner-list:not(.jamf-inner-list-expandable) thead tr:nth-child(odd){
+    background-color:#2F2F2F
+}
+/* 
+.jamf-list:not(.jamf-list-expandable) thead tr:nth-child(even),.jamf-list:not(.jamf-inner-list-expandable) thead tr:nth-child(even),.jamf-inner-list:not(.jamf-list-expandable) thead tr:nth-child(even),.jamf-inner-list:not(.jamf-inner-list-expandable) thead tr:nth-child(even){
+    background-color:#666666
+}
+*/
+
+.jamf-checkbox input+label>.check
+{
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+	pointer-events: none;
+	min-width: 26px;
+	margin-right: 16px;
+	border-radius: 2px;
+	background-color: #555555;
+	width: 26px;
+	height: 26px;
+	border: 1px solid #cbd0d8;
+	padding: 7px 5px 8px;
+	position: relative;
+	display: inline-flex;
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	justify-content: center;
+	-webkit-transition: background .3s,border .3s;
+	transition: background .3s,border .3s;
+}
+
+.jamf-checkbox input+label>.check g { fill: #555555; }
+
+.jamf-checkbox input:checked+label>.check
+{
+	border: 1px solid #268aff;
+	background-color: #268aff;
+}
+
+.jamf-checkbox input:checked+label>.check g { fill: #fff; }
+.jamf-checkbox input.error:not(:checked)+label>.check { border: 1px solid #d94453; }
+.jamf-checkbox input[disabled],.jamf-checkbox input.disabled { visibility: hidden; }
+.jamf-checkbox input[disabled]+label,.jamf-checkbox input.disabled+label { cursor: default; }
+.jamf-checkbox input[disabled]+label>.check,.jamf-checkbox input.disabled+label>.check { cursor: default; }
+.jamf-checkbox input[disabled]:not(:checked)+label>.check,.jamf-checkbox input.disabled:not(:checked)+label>.check { border: 1px solid #bfbfbf; }
+
+.jamf-checkbox input[disabled]:checked+label>.check,.jamf-checkbox input.disabled:checked+label>.check
+{
+	border: 1px solid #3f3f3f;
+	background-color: #3f3f3f;
+}
+
+.jamf-select-wrapper .jamf-select,.dataTables_wrapper .dataTables_paginate .paginate-input-wrapper .jamf-select,.datatables-pagination .dataTables_paginate .paginate-input-wrapper .jamf-select,.jamf-table-theme .ag-menu .ag-filter div div:not(.ag-filter-body):not(.ag-filter-apply-panel) select
+{
+	-webkit-transition-property: border-color;
+	transition-property: border-color;
+	-webkit-transition-duration: opacity;
+	transition-duration: opacity;
+	-webkit-transition-timing-function: 300ms;
+	transition-timing-function: 300ms;
+	-webkit-transition-delay: 0;
+	transition-delay: 0;
+	border-radius: 6px;
+	background-color: #3a3d44;
+	padding: 0 2.5rem 0 .5rem;
+	border: 1px solid #7f7f7f;
+	margin: 4px 0;
+	height: 34px;
+	color: #a2a2a2;
+	width: 100%;
+}
+
+.jamf-select-wrapper .jamf-select:hover,.dataTables_wrapper .dataTables_paginate .paginate-input-wrapper .jamf-select:hover,.datatables-pagination .dataTables_paginate .paginate-input-wrapper .jamf-select:hover,.jamf-table-theme .ag-menu .ag-filter div div:not(.ag-filter-body):not(.ag-filter-apply-panel) select:hover,.jamf-select-wrapper .jamf-select:active,.dataTables_wrapper .dataTables_paginate .paginate-input-wrapper .jamf-select:active,.datatables-pagination .dataTables_paginate .paginate-input-wrapper .jamf-select:active,.jamf-table-theme .ag-menu .ag-filter div div:not(.ag-filter-body):not(.ag-filter-apply-panel) select:active,.jamf-select-wrapper .jamf-select:focus,.dataTables_wrapper .dataTables_paginate .paginate-input-wrapper .jamf-select:focus,.datatables-pagination .dataTables_paginate .paginate-input-wrapper .jamf-select:focus,.jamf-table-theme .ag-menu .ag-filter div div:not(.ag-filter-body):not(.ag-filter-apply-panel) select:focus
+{
+	border: solid 1px #268aff;
+	cursor: pointer;
+}
+
+.jamf-select-wrapper,.dataTables_wrapper .dataTables_paginate .paginate-input-wrapper,.datatables-pagination .dataTables_paginate .paginate-input-wrapper,.jamf-table-theme .ag-menu .ag-filter div div:not(.ag-filter-body):not(.ag-filter-apply-panel)
+{
+	position: relative;
+	padding: 0;
+	margin: 0;
+	display: inline-block;
+}
+
+.jamf-select-wrapper::after,.dataTables_wrapper .dataTables_paginate .paginate-input-wrapper::after,.datatables-pagination .dataTables_paginate .paginate-input-wrapper::after,.jamf-table-theme .ag-menu .ag-filter div div:not(.ag-filter-apply-panel):not(.ag-filter-body)::after
+{
+	border: solid 4px;
+	border-color: #5b6982 transparent transparent transparent;
+	border-top-width: 5px;
+	content: "";
+	position: absolute;
+	top: 45%;
+	right: 14px;
+	font-size: 14px;
+	pointer-events: none;
+}
+
+
+.add-border{
+    border:1px solid #3b3b3b;
+}
+.add-border-left{
+    border-left:1px solid #3b3b3b;
+}
+.add-border-right{
+    border-right:1px solid #3b3b3b;
+}
+.indent{
+    border-left:1px solid #3b3b3b;
+    padding-left:28px
+}
+.generic-divider::after{
+    content:"";
+    border-left:1px solid #3b3b3b;
+    margin-left:14px;
+    margin-right:14px;
+    -ms-flex-item-align:stretch;
+    align-self:stretch
+}
+.label-value-wrapper:not(:first-of-type){
+    border-top:1px solid #555555;
+}
+.label-value-wrapper:last-of-type{
+    border-bottom:1px solid #555555;
+}
+
+.radio-button-wrapper .label .custom-control::after{
+    content:"";
+    position:absolute;
+    top:6px;
+    left:6px;
+    width:10px;
+    height:10px;
+    background:#555555;
+    -webkit-transition:.3s background;
+    transition:.3s background;
+    border-radius:14px
+}
+.jamf-category-list .dataTables_wrapper .jamf-inner-list tr td.group-item-expander, .configurationprofilelist .dataTables_wrapper .jamf-inner-list tr td.group-item-expander, .configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr td.group-item-expander, .policies .dataTables_wrapper .jamf-inner-list tr td.group-item-expander, .policiesdashboard .dataTables_wrapper .jamf-inner-list tr td.group-item-expander, .policyhistory .dataTables_wrapper .jamf-inner-list tr td.group-item-expander, .mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr td.group-item-expander, .ebooks .dataTables_wrapper .jamf-inner-list tr td.group-item-expander, .apps .dataTables_wrapper .jamf-inner-list tr td.group-item-expander {
+    width: 64px;
+    min-width: 0;
+    font-size: 18px;
+    color: #dddddd;
+    display: table-cell;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    padding-left: 5rem;
+    border-right: solid 1px #555555;
+    position: relative;
+}
+.jamf-category-list .dataTables_wrapper>.list-header,.configurationprofilelist .dataTables_wrapper>.list-header,.configurationprofilesdashboard .dataTables_wrapper>.list-header,.policies .dataTables_wrapper>.list-header,.policiesdashboard .dataTables_wrapper>.list-header,.policyhistory .dataTables_wrapper>.list-header,.mac-app-store-apps .dataTables_wrapper>.list-header,.ebooks .dataTables_wrapper>.list-header,.apps .dataTables_wrapper>.list-header{
+    overflow-x:auto;
+    overflow-y:hidden
+}
+.jamf-category-list .dataTables_wrapper .jamf-inner-list tr,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr,.policies .dataTables_wrapper .jamf-inner-list tr,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr,.policyhistory .dataTables_wrapper .jamf-inner-list tr,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr,.ebooks .dataTables_wrapper .jamf-inner-list tr,.apps .dataTables_wrapper .jamf-inner-list tr{
+    border-bottom:1px solid #555555;
+}
+.jamf-category-list .dataTables_wrapper .jamf-inner-list tr.odd+.details,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr.odd+.details,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr.odd+.details,.policies .dataTables_wrapper .jamf-inner-list tr.odd+.details,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr.odd+.details,.policyhistory .dataTables_wrapper .jamf-inner-list tr.odd+.details,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr.odd+.details,.ebooks .dataTables_wrapper .jamf-inner-list tr.odd+.details,.apps .dataTables_wrapper .jamf-inner-list tr.odd+.details{
+    background-color:#2F2F2F;
+}
+.jamf-category-list .dataTables_wrapper .jamf-inner-list tr.odd+.details .policy-details,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr.odd+.details .policy-details,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr.odd+.details .policy-details,.policies .dataTables_wrapper .jamf-inner-list tr.odd+.details .policy-details,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr.odd+.details .policy-details,.policyhistory .dataTables_wrapper .jamf-inner-list tr.odd+.details .policy-details,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr.odd+.details .policy-details,.ebooks .dataTables_wrapper .jamf-inner-list tr.odd+.details .policy-details,.apps .dataTables_wrapper .jamf-inner-list tr.odd+.details .policy-details,.jamf-category-list .dataTables_wrapper .jamf-inner-list tr.odd+.details .search-details,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr.odd+.details .search-details,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr.odd+.details .search-details,.policies .dataTables_wrapper .jamf-inner-list tr.odd+.details .search-details,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr.odd+.details .search-details,.policyhistory .dataTables_wrapper .jamf-inner-list tr.odd+.details .search-details,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr.odd+.details .search-details,.ebooks .dataTables_wrapper .jamf-inner-list tr.odd+.details .search-details,.apps .dataTables_wrapper .jamf-inner-list tr.odd+.details .search-details,.jamf-category-list .dataTables_wrapper .jamf-inner-list tr.odd+.details .spacer,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr.odd+.details .spacer,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr.odd+.details .spacer,.policies .dataTables_wrapper .jamf-inner-list tr.odd+.details .spacer,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr.odd+.details .spacer,.policyhistory .dataTables_wrapper .jamf-inner-list tr.odd+.details .spacer,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr.odd+.details .spacer,.ebooks .dataTables_wrapper .jamf-inner-list tr.odd+.details .spacer,.apps .dataTables_wrapper .jamf-inner-list tr.odd+.details .spacer{
+    background-color:#2F2F2F;
+}
+.jamf-category-list .dataTables_wrapper .jamf-inner-list tr.even+.details,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr.even+.details,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr.even+.details,.policies .dataTables_wrapper .jamf-inner-list tr.even+.details,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr.even+.details,.policyhistory .dataTables_wrapper .jamf-inner-list tr.even+.details,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr.even+.details,.ebooks .dataTables_wrapper .jamf-inner-list tr.even+.details,.apps .dataTables_wrapper .jamf-inner-list tr.even+.details{
+    background-color:#666666;
+}
+.jamf-category-list .dataTables_wrapper .jamf-inner-list tr.even+.details .policy-details,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr.even+.details .policy-details,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr.even+.details .policy-details,.policies .dataTables_wrapper .jamf-inner-list tr.even+.details .policy-details,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr.even+.details .policy-details,.policyhistory .dataTables_wrapper .jamf-inner-list tr.even+.details .policy-details,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr.even+.details .policy-details,.ebooks .dataTables_wrapper .jamf-inner-list tr.even+.details .policy-details,.apps .dataTables_wrapper .jamf-inner-list tr.even+.details .policy-details,.jamf-category-list .dataTables_wrapper .jamf-inner-list tr.even+.details .search-details,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr.even+.details .search-details,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr.even+.details .search-details,.policies .dataTables_wrapper .jamf-inner-list tr.even+.details .search-details,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr.even+.details .search-details,.policyhistory .dataTables_wrapper .jamf-inner-list tr.even+.details .search-details,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr.even+.details .search-details,.ebooks .dataTables_wrapper .jamf-inner-list tr.even+.details .search-details,.apps .dataTables_wrapper .jamf-inner-list tr.even+.details .search-details,.jamf-category-list .dataTables_wrapper .jamf-inner-list tr.even+.details .spacer,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr.even+.details .spacer,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr.even+.details .spacer,.policies .dataTables_wrapper .jamf-inner-list tr.even+.details .spacer,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr.even+.details .spacer,.policyhistory .dataTables_wrapper .jamf-inner-list tr.even+.details .spacer,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr.even+.details .spacer,.ebooks .dataTables_wrapper .jamf-inner-list tr.even+.details .spacer,.apps .dataTables_wrapper .jamf-inner-list tr.even+.details .spacer{
+    background-color:#666666;
+}
+.jamf-category-list .dataTables_wrapper .jamf-inner-list tr td.details,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr td.details,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr td.details,.policies .dataTables_wrapper .jamf-inner-list tr td.details,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr td.details,.policyhistory .dataTables_wrapper .jamf-inner-list tr td.details,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr td.details,.ebooks .dataTables_wrapper .jamf-inner-list tr td.details,.apps .dataTables_wrapper .jamf-inner-list tr td.details{
+    border-style:solid;
+    border-width:1px 0 1px 1px;
+    border-color:#555555;
+    position:relative;
+    top:-1px;
+    padding:0
+}
+.jamf-category-list .dataTables_wrapper .jamf-inner-list tr td.group,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr td.group,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr td.group,.policies .dataTables_wrapper .jamf-inner-list tr td.group,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr td.group,.policyhistory .dataTables_wrapper .jamf-inner-list tr td.group,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr td.group,.ebooks .dataTables_wrapper .jamf-inner-list tr td.group,.apps .dataTables_wrapper .jamf-inner-list tr td.group{
+    padding:24px 21px;
+    height:74px;
+    background-color:#66696F;
+    border-bottom:1px solid #555555;
+}
+.jamf-category-list .dataTables_wrapper .jamf-inner-list tr td.control,.configurationprofilelist .dataTables_wrapper .jamf-inner-list tr td.control,.configurationprofilesdashboard .dataTables_wrapper .jamf-inner-list tr td.control,.policies .dataTables_wrapper .jamf-inner-list tr td.control,.policiesdashboard .dataTables_wrapper .jamf-inner-list tr td.control,.policyhistory .dataTables_wrapper .jamf-inner-list tr td.control,.mac-app-store-apps .dataTables_wrapper .jamf-inner-list tr td.control,.ebooks .dataTables_wrapper .jamf-inner-list tr td.control,.apps .dataTables_wrapper .jamf-inner-list tr td.control{
+    width:64px;
+    min-width:0;
+    border-right:solid 1px #555555;
+}
+.jamf-searchbar{
+    border-bottom:1px solid #555555;
+    -webkit-box-align:center;
+    -ms-flex-align:center;
+    align-items:center;
+}
+.jamf-searchbar.boxed{
+    border:1px solid #555555;
+}
+.jamf-searchbar .jamf-search,.jamf-searchbar .legacy-jamf-search{
+    padding:0 25px;
+    height:82px;
+    border-right:1px solid #555555;
+}
+
+.jamf-searchbar .jamf-select-wrapper select,.jamf-searchbar .dataTables_wrapper .dataTables_paginate .paginate-input-wrapper select,.dataTables_wrapper .dataTables_paginate .jamf-searchbar .paginate-input-wrapper select,.jamf-searchbar .datatables-pagination .dataTables_paginate .paginate-input-wrapper select,.datatables-pagination .dataTables_paginate .jamf-searchbar .paginate-input-wrapper select{
+    color:#5b6982;
+    padding:0 25px;
+    height:82px;
+    border-right:1px solid #555555;
+    margin:0;
+    width:100%;
+    white-space:pre-line
+}
+
+.jamf-searchbar .jamf-searchbar-version{
+    height:82px;
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    -ms-flex-wrap:wrap;
+    flex-wrap:wrap;
+    -ms-flex-item-align:center;
+    align-self:center;
+    padding:1rem;
+    border-right:1px solid #555555;
+}
+
+select:hover {
+    background-color: #2f2f2f;
+}
+
+.jamf-settings-main{
+    -webkit-box-flex:1;
+    -ms-flex:1 1 auto;
+    flex:1 1 auto;
+    list-style:none;
+    margin:0;
+    height:100%;
+    width:100%;
+    overflow:auto;
+    -webkit-transform:translateZ(0);
+    transform:translateZ(0)
+}
+.jamf-settings-main .settings-section{
+    padding:30px 30px 30px 15px;
+    background-color:transparent;
+    margin-left:1px
+}
+.jamf-settings-main .settings-section:nth-child(even){
+    background-color:#2d2d2d;
+    -webkit-box-shadow:0 -1px 0 0 #555555,0 1px 0 0 #555555;
+    box-shadow:0 -1px 0 0 #555555,0 1px 0 0 #555555;
+}
+.jamf-settings-sidebar nav {
+    -webkit-box-flex: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+    width: 24vw;
+    padding-top: 15px;
+    padding-bottom: 80px;
+	background:transparent;
+    background-size:10px 10px
+    -webkit-box-shadow: 0 1px 0 0 #2f2f2f, 1px 0 0 0 #303030;
+    box-shadow: 0 1px 0 0 #2f2f2f, 1px 0 0 0 #303030;
+    position: fixed;
+    top: 69px;
+    overflow: auto;
+    bottom: 0;
+    left: 255px;
+}
+
+.jamf-section:nth-of-type(odd){
+    background-color:#282828
+}
+.jamf-section:nth-of-type(even){
+    background-color:#393939
+}
+.jamf-section.-reversed:first-of-type{
+    margin-top:-28px
+}
+.jamf-section.-reversed:nth-of-type(odd){
+    background-color:#282828
+}
+.jamf-section.-reversed:nth-of-type(even){
+    background-color:#393939
+}
+.jamf-section.featured{
+    background:#555A5F
+}
+.jamf-section.white{
+    background:#6F6F6F
+}
+.jamf-section .pages .page-row:nth-of-type(odd){
+    background-color:#282828
+}
+.jamf-section .pages .page-row:nth-of-type(even){
+    background-color:#393939
+}
+
+.jamf-subtabs
+{
+	margin-bottom: 28px;
+	border: 1px solid #cbd0d8;
+	border-radius: 5px;
+	background: transparent;
+	overflow: hidden;
+    font-weight: 600;
+}
+
+.jamf-subtabs ul
+{
+	list-style: none;
+	margin: -1px -2px -1px -1px;
+	display: flex;
+	overflow: auto;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
+}
+
+.jamf-subtabs ul li
+{
+	border-top: 1px solid #cbd0d8;
+	border-right: 1px solid #cbd0d8;
+	background-color: #555a5f;
+	color: #666;
+	cursor: pointer;
+	padding: 10px;
+	line-height: 1;
+	text-align: center;
+	display: flex;
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+	-webkit-box-flex: 1;
+	-ms-flex-positive: 1;
+	flex-grow: 1;
+}
+
+.jamf-subtabs ul li a
+{
+	color: #666;
+	-webkit-box-flex: 1;
+	-ms-flex-positive: 1;
+	flex-grow: 1;
+}
+
+.jamf-subtabs ul li span
+{
+	padding: 0 2px;
+	display: block;
+	margin: 0 auto;
+}
+
+.jamf-subtabs ul li.active,.jamf-subtabs ul li.active a span
+{
+	-webkit-text-stroke: .4px #5b6982;
+	color: #ffffff;
+	background: #4b659c;
+}
+
+.jamf-subtabs ul li.inactive,.jamf-subtabs ul li.inactive a span
+{
+	-webkit-text-stroke: .4px #5b6982;
+	color: #a7bee8;
+	background: #404a5f;
+}
+
+apps-autocomplete table ul li.active,apps-autocomplete table ul li:hover{
+    background:#555A5F;
+    color:#666
+}
+.jamf-table-theme
+{
+	background-color: #333333;
+	color: #dddddd;
+}
+
+.jamf-table-theme .ag-header
+{
+	color: #a0b7e0;
+    background-color: #555555;
+}
+
+.jamf-table-theme .ag-tab-header{
+    background:#555A5F;
+    min-width:220px;
+    width:100%;
+    display:table
+}
+.jamf-table-theme .ag-column-drop-horizontal{
+    background-color:#555A5F;
+    height:40px;
+    line-height:32px;
+    padding-left:16px
+}
+.jamf-table-theme{
+    background-color:#363636;
+    color:#666;
+    font:400 14px
+}
+
+.jamf-table-theme .ag-row-odd{
+    background-color:#282828;
+}
+.jamf-table-theme .ag-row-even{
+    background-color:#393939;
+}
+.ui-grid-row:nth-child(odd) .ui-grid-cell,.ui-grid-row-selected.ui-grid-row:nth-child(odd) .ui-grid-cell,.expandableRow .ui-grid-row:nth-child(odd) .ui-grid-cell,.ui-grid-pager-control input,.ui-grid-pager-row-count-picker select{
+    background-color:#6F6F6F
+}
+.ui-grid-row:nth-child(even) .ui-grid-cell,.ui-grid-row-selected.ui-grid-row:nth-child(even) .ui-grid-cell{
+    background-color:#555A5F
+}
+#fixed-buttons{
+    background:-webkit-gradient(linear,left top,left bottom,from(rgba(24,24,24,0)),color-stop(25%,rgba(24,24,24,0.75)),color-stop(50%,rgba(24,24,24,0.95)));
+    background:linear-gradient(to bottom,rgba(24,24,24,0) 0,rgba(24,24,24,0.75) 25%,rgba(24,24,24,0.95) 50%);
+    position:fixed;
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    -webkit-box-align:start;
+    -ms-flex-align:start;
+    align-items:flex-start;
+    -ms-flex-wrap:wrap;
+    flex-wrap:wrap;
+    bottom:0;
+    right:0;
+    left:255px;
+    padding:21px;
+    -webkit-transform:translate3d(0,0,0);
+    transform:translate3d(0,0,0);
+    z-index:21
+}
+.modal-dialog {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    position: relative;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+    background-color: #000000;
+    color: #dddddd;
+    padding: 0;
+    border-radius: 10px;
+    margin: 25px;
+    min-width: 300px;
+    max-height: 80vh;
+    height: auto;
+}
+.modal-dialog .modal-header h1 {
+    font-size: 20px;
+    font-weight: 600;
+    color: #dddddd;
+    margin: 0;
+}
+
+.modal-dialog .modal-footer 
+{
+    background: #000000;
+    background-color: #000000;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-pack: justify;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    z-index: 1;
+}
+.modal-dialog .modal-body p {
+    color: #dddddd;
+    font-size: 14px;
+    margin-bottom: 1rem;
+    line-height: 17px;
+}
+
+.jamf-alert-success
+{
+	border-color: #8bc052;
+	background-color: #1f2f3f;
+}
+
+.jamf-alert-success .jamf-alert-icon { color: #8bc052; }
+.jamf-alert-success .jamf-alert-icon::before { content: "\e9fa"; }
+
+.jamf-alert-secure
+{
+	border-color: #8bc052;
+	background-color: #1f2f3f;
+}
+
+.jamf-alert-secure .jamf-alert-icon { color: #8bc052; }
+.jamf-alert-secure .jamf-alert-icon::before { content: "\ea38"; }
+
+.jamf-alert-info
+{
+	border-color: #268aff;
+	background-color: #1f2f3f;
+}
+
+.jamf-alert-info .jamf-alert-icon { color: #268aff; }
+.jamf-alert-info .jamf-alert-icon::before { content: "\ea2b"; }
+
+.jamf-alert-warning
+{
+	border-color: #f5ba42;
+	background-color: #1f2f3f;
+}
+
+.jamf-alert-warning .jamf-alert-icon { color: #f5ba42; }
+.jamf-alert-warning .jamf-alert-icon::before { content: "\ea83"; }
+
+.jamf-alert-warning-critical
+{
+	border-color: #d94453;
+	background-color: #1f2f3f;
+}
+
+.jamf-alert-warning-critical .jamf-alert-icon { color: #d94453; }
+.jamf-alert-warning-critical .jamf-alert-icon::before { content: "\ea83"; }
+
+.jamf-alert-error
+{
+	border-color: #d94453;
+	background-color: #1f2f3f;
+}
+
+.jamf-alert-error .jamf-alert-icon { color: #d94453; }
+.jamf-alert-error .jamf-alert-icon::before { content: "\ea9c"; }
+
+
+.ui-grid-cell-contents
+{
+	padding: 15px 25px;
+	color: #dddddd;
+}
+
+.ui-grid-cell-contents a
+{
+	color: #b0cfff;
+	font-weight: 700;
+	text-shadow: 1px 1px 0 #3f3f3f;
+}
+

--- a/jamfpro.css
+++ b/jamfpro.css
@@ -31,6 +31,12 @@ h1, h2, h3, h4, h5, h6 {
     font-size: 14px;
 }
 
+html, body, .jamf-list tbody td, .jamf-inner-list tbody td, .jamf-label {
+    color: #DDDDDD;
+    background: #2f2f2f;
+}
+
+
 input {
     background-color: #4e5a6f;
     color: #ffffff;
@@ -88,11 +94,6 @@ input.disabled.jamf-input-text, .jamf-table-theme input.disabled.ag-filter-filte
     background-color: #414753;
 }
 
-html, body, .jamf-list tbody td, .jamf-inner-list tbody td, .jamf-label {
-    color: #DDDDDD;
-    background: inherit;
-}
-
 .jamf-list tbody td a, .jamf-inner-list tbody td a {
     color: #307fff;
 }
@@ -116,6 +117,7 @@ html, body, .jamf-list tbody td, .jamf-inner-list tbody td, .jamf-label {
     background-color:#6f6f6f
 }
 .nav-group-header {
+    font-family: ProximaNova,"Helvetica Nueu",Verdana,sans-serif;
     font-weight: 700;
     color: #dddddd;
     text-transform: uppercase;
@@ -180,6 +182,7 @@ html, body, .jamf-list tbody td, .jamf-inner-list tbody td, .jamf-label {
 }
 
 .jamf-pro-dashboard #dashboard-container .dashboard-content h3 a, .jamf-pro-dashboard #dashboard-container .dashboard-content h3 a.view-all, .jamf-pro-dashboard #dashboard-container .dashboard-content h3.view-all, .configurationprofilesdashboard #dashboard-container .dashboard-content h3 a, .configurationprofilesdashboard #dashboard-container .dashboard-content h3 a.view-all, .configurationprofilesdashboard #dashboard-container .dashboard-content h3.view-all, .distributionserverdashboard #dashboard-container .dashboard-content h3 a, .distributionserverdashboard #dashboard-container .dashboard-content h3 a.view-all, .distributionserverdashboard #dashboard-container .dashboard-content h3.view-all, .policiesdashboard #dashboard-container .dashboard-content h3 a, .policiesdashboard #dashboard-container .dashboard-content h3 a.view-all, .policiesdashboard #dashboard-container .dashboard-content h3.view-all {
+    font-family: ProximaNova,"Helvetica Nueu",Verdana,sans-serif;
     font-size: 17px;
     font-weight: 600;
     color: #dddddd;
@@ -1039,7 +1042,7 @@ apps-autocomplete table ul li.active,apps-autocomplete table ul li:hover{
 .jamf-table-theme{
     background-color:#363636;
     color:#666;
-    font:400 14px
+    font:400 14px ProximaNova,"Helvetica Neue",Verdana,sans-serif
 }
 
 .jamf-table-theme .ag-row-odd{


### PR DESCRIPTION
I've gone through all the major areas of Jamf Pro and refined the theme colors for a better 'dark mode' experience.  Still left to do: scope tables and buttons.